### PR TITLE
Alphastable fit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.0.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/AlphaStableDistributions.jl
+++ b/src/AlphaStableDistributions.jl
@@ -177,10 +177,11 @@ const ϕ₅ = [
 ]
 
 """
+    fit(d::Type{<:AlphaStable}, x; alg=QuickSort)
+
 Fit an α stable distribution to data.
 
-:param x: data
-:returns: (α, β, c, δ)
+returns `AlphaStable`
 
 α, β, c and δ are the characteristic exponent, skewness parameter, scale parameter
 (dispersion^1/α) and location parameter respectively.

--- a/src/AlphaStableDistributions.jl
+++ b/src/AlphaStableDistributions.jl
@@ -250,7 +250,7 @@ function Distributions.fit(::Type{<:SymmetricAlphaStable}, x)
     if α < 0.5
         α = 0.5
     end
-    return AlphaStable(α=α, β=zero(α), scale=c, location=oftype(α, δ))
+    return SymmetricAlphaStable(α=α, scale=c, location=oftype(α, δ))
 end
 
 """

--- a/src/AlphaStableDistributions.jl
+++ b/src/AlphaStableDistributions.jl
@@ -436,7 +436,7 @@ function Distributions.fit(d::Type{<:AlphaSubGaussian}, x::AbstractVector{T}, m:
     α    = d1.α; scale=d1.scale
     cov  = zeros(T, m+1, m+1)
     xlen = length(x)
-    c    = ((sum(abs.(x).^p)/xlen)^(1/p))/scale
+    c    = ((sum(x->abs(x)^p, x)/xlen)^(1/p))/scale
     for i in 1:m
         tempxlen = xlen-mod(xlen, i)
         xtemp = reshape(x[1:end-mod(xlen, i)], i, tempxlen÷i)
@@ -445,7 +445,7 @@ function Distributions.fit(d::Type{<:AlphaSubGaussian}, x::AbstractVector{T}, m:
             tempxlen = size(xtemp, 1)*size(xtemp, 2)
         end
         xtemp = reshape(xtemp', 2, tempxlen÷2)
-        r = (2/(c^p))*(scale^(2-p))*(xtemp[1, :]'*((sign.(xtemp[2, :]).*(abs.(xtemp[2, :]).^(p-1)))))/(tempxlen/2)
+        @views r = (2/(c^p))*(scale^(2-p))*(xtemp[1, :]'*((sign.(xtemp[2, :]).*(abs.(xtemp[2, :]).^(p-1)))))/(tempxlen/2)
         cov[diagind(cov, i)] .+= r
     end
     cov = (cov+cov')+2*(scale^2)*I(m+1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ using Test, Random, Distributions
         xcauchy = rand(Cauchy(3.0, 4.0), 96000)
         d = fit(stabletype, xcauchy)
         @test d.α ≈ 1 rtol=0.2
-        @test d.β ≈ 0 atol=0.2
+        stabletype != SymmetricAlphaStable && @test d.β ≈ 0 atol=0.2
         @test d.scale ≈ 4 rtol=0.2
         @test d.location ≈ 3 rtol=0.1
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using Test, Random, Distributions
         @test d1.α ≈ d2.α rtol=0.1
         @test d1.β ≈ d2.β atol=0.2
         @test d1.scale ≈ d2.scale rtol=0.1
-        @test d1.location ≈ d2.location atol=0.2
+        @test d1.location ≈ d2.location atol=0.1
     end
 
     xnormal = rand(Normal(3.0, 4.0), 96000)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,19 +1,33 @@
 using AlphaStableDistributions
-using Test, Random
+using Test, Random, Distributions
 
 @testset "AlphaStableDistributions.jl" begin
 
-    for α in 0.5:0.1:2
+    for α in 0.6:0.1:2
         d1 = AlphaStable(α=α)
         s = rand(d1, 100000)
 
         d2 = fit(AlphaStable, s)
 
         @test d1.α ≈ d2.α rtol=0.1
-        @test d1.β ≈ d2.β rtol=0.1
+        @test d1.β ≈ d2.β atol=0.2
         @test d1.scale ≈ d2.scale rtol=0.1
-        @test d1.location ≈ d2.location atol=0.03
+        @test d1.location ≈ d2.location atol=0.2
     end
+
+    xnormal = rand(Normal(3.0, 4.0), 96000)
+    d = fit(AlphaStable, xnormal)
+    @test d.α ≈ 2 rtol=0.2
+    @test d.β ≈ 0 atol=0.2
+    @test d.scale ≈ 4/√2 rtol=0.2
+    @test d.location ≈ 3 rtol=0.1
+
+    xcauchy = rand(Cauchy(3.0, 4.0), 96000)
+    d = fit(AlphaStable, xcauchy)
+    @test d.α ≈ 1 rtol=0.2
+    @test d.β ≈ 0 atol=0.2
+    @test d.scale ≈ 4 rtol=0.2
+    @test d.location ≈ 3 rtol=0.1
 
     for α in 1.1:0.1:1.9
 
@@ -25,9 +39,9 @@ using Test, Random
 
         d3 = fit(AlphaStable, x)
         @test d3.α ≈ α rtol=0.2
-        @test d3.β == 0
+        @test d3.β ≈ 0 atol=0.2
         @test d3.scale ≈ 1 rtol=0.2
-        @test d3.location ≈ 0 atol=0.03
+        @test d3.location ≈ 0 atol=0.1
     end
 
     d4 = AlphaSubGaussian(n=96000)
@@ -86,9 +100,3 @@ end
 # using Cthulhu
 # d = AlphaSubGaussian(n=96)
 # @descend_code_warntype rand(Random.GLOBAL_RNG, d)
-# 
-# using AlphaStableDistributions
-# d1 = AlphaStable(α=1.5)
-# s = rand(d1, 100000)
-# using ThreadsX
-# @btime fit($AlphaStable, $s, $ThreadsX.MergeSort)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,34 +3,37 @@ using Test, Random, Distributions
 
 @testset "AlphaStableDistributions.jl" begin
 
-    for α in 0.6:0.1:2
-        d1 = AlphaStable(α=α)
-        s = rand(d1, 100000)
+    stabletypes = [AlphaStable,SymmetricAlphaStable]
+    αs = [0.6:0.1:2,1:0.1:2]
+    for (i, stabletype) in enumerate(stabletypes)
+        for α in αs[i]
+            d1 = AlphaStable(α=α)
+            s = rand(d1, 100000)
 
-        d2 = fit(AlphaStable, s)
+            d2 = fit(stabletype, s)
 
-        @test d1.α ≈ d2.α rtol=0.1
-        @test d1.β ≈ d2.β atol=0.2
-        @test d1.scale ≈ d2.scale rtol=0.1
-        @test d1.location ≈ d2.location atol=0.1
+            @test d1.α ≈ d2.α rtol=0.1
+            stabletype != SymmetricAlphaStable && @test d1.β ≈ d2.β atol=0.2
+            @test d1.scale ≈ d2.scale rtol=0.1
+            @test d1.location ≈ d2.location atol=0.1
+        end
+
+        xnormal = rand(Normal(3.0, 4.0), 96000)
+        d = fit(stabletype, xnormal)
+        @test d.α ≈ 2 rtol=0.2
+        stabletype != SymmetricAlphaStable && @test d.β ≈ 0 atol=0.2
+        @test d.scale ≈ 4/√2 rtol=0.2
+        @test d.location ≈ 3 rtol=0.1
+
+        xcauchy = rand(Cauchy(3.0, 4.0), 96000)
+        d = fit(stabletype, xcauchy)
+        @test d.α ≈ 1 rtol=0.2
+        @test d.β ≈ 0 atol=0.2
+        @test d.scale ≈ 4 rtol=0.2
+        @test d.location ≈ 3 rtol=0.1
     end
 
-    xnormal = rand(Normal(3.0, 4.0), 96000)
-    d = fit(AlphaStable, xnormal)
-    @test d.α ≈ 2 rtol=0.2
-    @test d.β ≈ 0 atol=0.2
-    @test d.scale ≈ 4/√2 rtol=0.2
-    @test d.location ≈ 3 rtol=0.1
-
-    xcauchy = rand(Cauchy(3.0, 4.0), 96000)
-    d = fit(AlphaStable, xcauchy)
-    @test d.α ≈ 1 rtol=0.2
-    @test d.β ≈ 0 atol=0.2
-    @test d.scale ≈ 4 rtol=0.2
-    @test d.location ≈ 3 rtol=0.1
-
     for α in 1.1:0.1:1.9
-
         d = AlphaSubGaussian(n=96000, α=α)
         x = rand(d)
         x2 = copy(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,3 +100,9 @@ end
 # using Cthulhu
 # d = AlphaSubGaussian(n=96)
 # @descend_code_warntype rand(Random.GLOBAL_RNG, d)
+# 
+# using AlphaStableDistributions
+# d1 = AlphaStable(α=1.5)
+# s = rand(d1, 100000)
+# using ThreadsX
+# @btime fit($AlphaStable, $s, $ThreadsX.MergeSort)


### PR DESCRIPTION
The current `AlphaStable` fit  based on Fama & Roll (1971) is limited to Symmetric Alpha Stable Distributions (as discussed in #19). This PR implements a more general  `AlphaStable` fit based on McCulloch (1986) for `alpha` in the range of `[0.6, 2.0]` and `beta` in the range of `[-1, 1]`.