### PR TITLE
Add compatibility with Interpolations.jl v0.14

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 
 [compat]
 Distributions = "0.21, 0.22, 0.23, 0.24, 0.25"
-Interpolations = "0.12, 0.13"
+Interpolations = "0.12, 0.13, 0.14"
 MAT = "0.6, 0.7, 0.8, 0.9, 0.10"
 SpecialFunctions = "0.8, 0.9, 0.10, 1.0, 2"
 StaticArrays = "0.12, 1.1"


### PR DESCRIPTION
I checked [Implement inplace GriddedInterpolation #496](https://github.com/JuliaMath/Interpolations.jl/pull/496) to figure out if these changes would break the usage of `interpolate`, but there's no modification being done to the constants used as grids for itp1 and itp2. The output from calling itp1 and itp2 remains the same here.